### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "main": "index.js",
   "dependencies": {
+    "babel": "4.7.x",
     "babel-runtime": "4.7.x",
     "express": "4.x.x",
     "co": "4.5.x",
@@ -26,7 +27,6 @@
     "negotiator": "0.5.x"
   },
   "devDependencies": {
-    "babel": "4.7.x",
     "babel-eslint": "2.x.x",
     "eslint": "^0.x.x",
     "chai": "~1.9.0",


### PR DESCRIPTION
When you do an `npm install` with a `--production` flag it will not install babel.

In `json-api/src/adapters/Mongoose/MongooseAdapter` there's a line of code where it states  `import polyfill from "babel/polyfill";`. This basically means that with or without a production flag `babel` needs to be imported. 

This pull request is just moving it from the devDependencies to dependencies in general. When your default `NODE_ENV` is set to production then you NPM will automatically only install the dependencies and this will become an issue.