### PR TITLE
Allow transforms to return Promises

### DIFF
--- a/src/controllers/API.js
+++ b/src/controllers/API.js
@@ -78,7 +78,7 @@ class APIController {
             yield validateRequestResources(request.type, parsedPrimary, registry);
           }
 
-          request.primary = applyTransform(
+          request.primary = yield applyTransform(
             parsedPrimary, "beforeSave", registry, frameworkReq, frameworkRes
           );
         }
@@ -154,11 +154,11 @@ class APIController {
       }
 
       // apply transforms pre-send
-      response.primary = applyTransform(
+      response.primary = yield applyTransform(
         response.primary, "beforeRender", registry, frameworkReq, frameworkRes
       );
 
-      response.included = applyTransform(
+      response.included = yield applyTransform(
         response.included, "beforeRender", registry, frameworkReq, frameworkRes
       );
 

--- a/test/app/src/resource-descriptions/organizations.js
+++ b/test/app/src/resource-descriptions/organizations.js
@@ -2,5 +2,9 @@ module.exports = {
   urlTemplates: {
     "self": "http://127.0.0.1:3000/organizations/{id}",
     "relationship": "http://127.0.0.1:3000/organizations/{ownerId}/links/{path}"
+  },
+  beforeSave: function(resource) {
+    resource.attrs.description = "Added a description in beforeSave";
+    return resource;
   }
 };

--- a/test/app/src/resource-descriptions/schools.js
+++ b/test/app/src/resource-descriptions/schools.js
@@ -1,3 +1,5 @@
+import { Promise } from "q";
+
 module.exports = {
   parentType: "organizations",
   urlTemplates: {
@@ -19,5 +21,12 @@ module.exports = {
         "description": "Whether the school is a college, by the U.S. meaning."
       }
     }
+  },
+
+  beforeSave: function(resource) {
+    return new Promise((resolve, reject) => {
+      resource.attrs.description = "Modified in a Promise";
+      resolve(resource);
+    });
   }
 };

--- a/test/integration/create-resource/index.js
+++ b/test/integration/create-resource/index.js
@@ -1,6 +1,10 @@
 import {expect} from "chai";
 import AgentPromise from "../../app/agent";
-import {ORG_RESOURCE_CLIENT_ID, VALID_ORG_RESOURCE_NO_ID_EXTRA_MEMBER} from "../fixtures/creation";
+import {
+  ORG_RESOURCE_CLIENT_ID,
+  VALID_ORG_RESOURCE_NO_ID_EXTRA_MEMBER,
+  VALID_SCHOOL_RESOURCE_NO_ID
+} from "../fixtures/creation";
 
 describe("", (describeDone) => {
   AgentPromise.then((Agent) => {
@@ -41,6 +45,26 @@ describe("", (describeDone) => {
 
             describe("Links", () => {
 
+            });
+            
+            describe("Transforms", () => {
+              describe("beforeSave", () => {
+                it("should execute beforeSave hook", (done) => {
+                  expect(createdResource.attributes.description).to.equal("Added a description in beforeSave");
+                  done();
+                });
+
+                it("should allow beforeSave to return a Promise", (done) => {
+                  Agent.request("POST", "/schools")
+                    .type("application/vnd.api+json")
+                    .send({"data": VALID_SCHOOL_RESOURCE_NO_ID})
+                    .promise()
+                    .then((res) => {
+                      expect(res.body.data.attributes.description).to.equal("Modified in a Promise");
+                      done();
+                    }, done).catch(done);
+                });
+              });
             });
 
             describe("The Created Resource", () => {

--- a/test/integration/fixtures/creation.js
+++ b/test/integration/fixtures/creation.js
@@ -17,3 +17,10 @@ export const VALID_ORG_RESOURCE_NO_ID_EXTRA_MEMBER = Object.assign(
 export const ORG_RESOURCE_CLIENT_ID = Object.assign(
   {"id": "53f54dd98d1e62ff12539db3"}, VALID_ORG_RESOURCE_NO_ID
 );
+
+export const VALID_SCHOOL_RESOURCE_NO_ID = {
+  "type": "schools",
+  "attributes": {
+    "name": "Test School"
+  }
+};


### PR DESCRIPTION
Closes #31.

Example syntax can be found in [tests](https://github.com/ethanresnick/json-api/compare/master...andrewbranch:async-transforms?expand=1#diff-3d74f0595cd532c6427ebce224e87fdaR29):

```javascript
  ...

  beforeSave: function(resource) {
    return new Promise((resolve, reject) => {
      resource.attrs.description = "Modified in a Promise";
      resolve(resource);
    });
  }
```