### PR TITLE
Improve error handling for poorly formed relationships

### DIFF
--- a/test/integration/create-resource/index.js
+++ b/test/integration/create-resource/index.js
@@ -3,7 +3,8 @@ import AgentPromise from "../../app/agent";
 import {
   ORG_RESOURCE_CLIENT_ID,
   VALID_ORG_RESOURCE_NO_ID_EXTRA_MEMBER,
-  VALID_SCHOOL_RESOURCE_NO_ID
+  VALID_SCHOOL_RESOURCE_NO_ID,
+  INVALID_ORG_RESOURCE_NO_DATA_IN_RELATIONSHIP
 } from "../fixtures/creation";
 
 describe("", () => {
@@ -99,6 +100,40 @@ describe("", () => {
           describe("Document Structure", () => {
             it("should contain an error", () => {
               expect(err.response.body.errors).to.be.an("array");
+            });
+          });
+        });
+      }).done();
+  }).done();
+});
+
+describe("", () => {
+  AgentPromise.then((Agent) => {
+    Agent.request("POST", "/organizations")
+      .type("application/vnd.api+json")
+      .send({"data": INVALID_ORG_RESOURCE_NO_DATA_IN_RELATIONSHIP})
+      .promise()
+      .then(() => { throw new Error("Should not run!"); }, (err) => {
+        describe("Creating a Resource With a Missing Relationship Data Key", () => {
+          describe("HTTP", () => {
+            it("should return 400", () => {
+              expect(err.response.status).to.equal(400);
+            });
+          });
+
+          describe("Document Structure", () => {
+            it("should contain an error", () => {
+              expect(err.response.body.errors).to.be.an("array");
+            });
+          });
+
+          describe("Error", () => {
+            it("should have the correct title", () => {
+              expect(err.response.body.errors[0].title).to.be.equal("Missing relationship linkage.");
+            });
+
+            it("should have the correct details", () => {
+              expect(err.response.body.errors[0].details).to.be.equal("No data was found for the liaisons relationship.");
             });
           });
         });

--- a/test/integration/fixtures/creation.js
+++ b/test/integration/fixtures/creation.js
@@ -24,3 +24,12 @@ export const VALID_SCHOOL_RESOURCE_NO_ID = {
     "name": "Test School"
   }
 };
+
+export const INVALID_ORG_RESOURCE_NO_DATA_IN_RELATIONSHIP = {
+  "type": "organizations",
+  "relationships": {
+    "liaisons": {
+      "type": "people", "id": "53f54dd98d1e62ff12539db3"
+    }
+  }
+};


### PR DESCRIPTION
Tells the user what they did wrong when they forget to wrap their relationship changes in a `{ data: ... }` object