### PR TITLE
Related with no data

### DIFF
--- a/build/src/types/Document.js
+++ b/build/src/types/Document.js
@@ -102,7 +102,7 @@ var Document = (function () {
 exports["default"] = Document;
 
 function linkageToJSON(linkage) {
-  return linkage.value;
+  return linkage && linkage.value;
 }
 
 function relationshipObjectToJSON(linkObject, urlTemplates, templateData) {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ module.exports = {
     Documentation: {
       Field: require('./build/src/types/Documentation/Field'),
       FieldType: require('./build/src/types/Documentation/FieldType')
-    }
+    },
+    RelationshipObject: require('./build/src/types/RelationshipObject')
   },
   controllers: {
     API: require('./build/src/controllers/API'),

--- a/src/types/Document.js
+++ b/src/types/Document.js
@@ -67,7 +67,7 @@ export default class Document {
 }
 
 function linkageToJSON(linkage) {
-  return linkage.value;
+  return linkage && linkage.value;
 }
 
 function relationshipObjectToJSON(linkObject, urlTemplates, templateData) {


### PR DESCRIPTION
As per your suggestion this is to solve #95 

It's a very simple change but it didn't quite work the way you had suggested.

For example this is how I had to describe the resource:

```javascript
{
  type: 'groups',
  urlTemplates: {
    self: '/api/v1/groups/{id}',
    related: '/api/v1/{path}?filter[simple][group]={ownerId}'
  },
  beforeRender: function(resource) {
    resource.relationships.projects = new jsonApi.types.RelationshipObject();
    return resource;
  }
}
```

And it results in a document that looks like this:

```javascript
{
  "links": {
    "self": "http://localhost:8001/api/v1/groups"
  },
  "data": [
    {
      "id": "5621a3dbfb9398f40bcd7579",
      "type": "groups",
      "attributes": {
        "name": "test group"
      },
      "links": {
        "self": "/api/v1/groups/5621a3dbfb9398f40bcd7579"
      },
      "relationships": {
        "projects": {
          "links": {
            "related": "/api/v1/projects?filter%5Bsimple%5D%5Bgroup%5D=5621a3dbfb9398f40bcd7579"
          }
        }
      }
    }
  ]
}
```

So the end result is good but I'm concerned about the fact that I had to add related in urlTemplate for two reasons. 

One, when I added it to the RelationshipObject as you suggested:
```javascript
resource.relationships.projects = new RelationshipObject(undefined, '/api/v1/{path}?filter[simple][group]={ownerId}');
```
It ended up giving me a document that looked like this:
```javascript
{
  "links": {
    "self": "http://localhost:8001/api/v1/groups"
  },
  "data": [
    {
      "id": "5621a3dbfb9398f40bcd7579",
      "type": "groups",
      "attributes": {
        "name": "test group"
      },
      "links": {
        "self": "/api/v1/groups/5621a3dbfb9398f40bcd7579"
      },
      "relationships": {
        "projects": {}
      }
    }
  ]
}
```
There is obviously something more going on here that I need go through the source more for. Maybe you can shed some light on this for me.

The second reason is that the related key in urlTemplates is not actually documented so I'm not sure I am using it correctly or if I even should be using it.