### PR TITLE
Cоmplete fix #109 issue

### DIFF
--- a/build/src/db-adapters/Mongoose/MongooseAdapter.js
+++ b/build/src/db-adapters/Mongoose/MongooseAdapter.js
@@ -637,13 +637,20 @@ var MongooseAdapter = (function () {
           return new _typesDocumentationFieldType2["default"]("Id", false);
         }
 
-        var typeOptions = schemaType.options.type;
-        var holdsArray = Array.isArray(typeOptions);
-
-        var baseType = holdsArray ? typeOptions[0].ref : typeOptions.name;
+        var holdsArray = Array.isArray(schemaType.options.type);
         var refModelName = util.getReferencedModelName(model, path);
 
-        return !refModelName ? new _typesDocumentationFieldType2["default"](baseType, holdsArray) : new _typesDocumentationRelationshipType2["default"](holdsArray, refModelName, _this7.getType(refModelName, pluralizer));
+        if (refModelName) {
+          return new _typesDocumentationRelationshipType2["default"](holdsArray, refModelName, _this7.getType(refModelName, pluralizer));
+        }
+
+        var typeOptions = holdsArray ? schemaType.options.type[0] : schemaType.options.type;
+
+        var isEmbeddedDocument = ["SchemaType", "DocumentArray"].includes(schemaType.constructor.name);
+
+        var baseType = isEmbeddedDocument ? "EmbeddedDocument" : typeOptions.name;
+
+        return new _typesDocumentationFieldType2["default"](baseType, holdsArray);
       };
 
       model.schema.eachPath(function (name, type) {


### PR DESCRIPTION
`schemaType.options.type[0].ref` is only present in the case of relationship with another model, and is absent in the other cases (**single** relationship, array of symple types or subdocs). In the case when the field is a sub-document, relationship with another model or an array of sub-documents or relationships, we do not need to touch any `schemaType.options.type[0].ref`, or `schemaType.options.type[0].name`:

``` javascript
var typeOptions = holdsArray ?
  schemaType.options.type[0] :
  schemaType.options.type;

var isEmbeddedDocument = (
  schemaType.constructor.name === "SchemaType" ||
  schemaType.constructor.name === "DocumentArray"
);

var baseType = isEmbeddedDocument ?
  "EmbeddedDocument":
  typeOptions.name;
```

However, if the field will be an array of relationships, the `typeOptions.name` will be equal to `undefined`. We should not really worry about it, since under this condition to baseType is no longer appeals. But this implicit behavior, which in the further development can lead to errors. That it could not happen, we need to explicitly specify the behavior for this case.
