### PR TITLE
Make the docs controller optional when constructing HTTP strategies

### DIFF
--- a/src/http-strategies/Base.ts
+++ b/src/http-strategies/Base.ts
@@ -41,12 +41,12 @@ export type Controller =
  */
 export default class BaseStrategy {
   protected api: APIController;
-  protected docs: DocsController;
+  protected docs?: DocsController;
   protected config: HTTPStrategyOptions;
 
   constructor(
     apiController: APIController,
-    docsController: DocsController,
+    docsController?: DocsController,
     options?: HTTPStrategyOptions
   ) {
     this.api = apiController;

--- a/src/http-strategies/Express.ts
+++ b/src/http-strategies/Express.ts
@@ -44,7 +44,7 @@ const deprecate = depd("json-api");
  *    can set this option to false to have this code just pass on to Express.
  */
 export default class ExpressStrategy extends Base {
-  constructor(apiController, docsController, options?: HTTPStrategyOptions) {
+  constructor(apiController, docsController?, options?: HTTPStrategyOptions) {
     super(apiController, docsController, options);
   }
 
@@ -130,7 +130,14 @@ export default class ExpressStrategy extends Base {
    * See: https://expressjs.com/en/guide/migrating-5.html#req.host
    * The workaround is to use the host configuration option.
    */
-  docsRequest: RequestHandler = R.partial(this.doRequest, [this.docs.handle]);
+  get docsRequest(): RequestHandler {
+    if (this.docs == null) {
+      throw new Error('Cannot get docs request handler. '
+        + 'No docs controller was provided to the HTTP strategy.');
+    }
+
+    return R.partial(this.doRequest, [this.docs.handle]);
+  };
 
   /**
    * A middleware to handle supported API requests.

--- a/src/http-strategies/Express.ts
+++ b/src/http-strategies/Express.ts
@@ -136,8 +136,10 @@ export default class ExpressStrategy extends Base {
         + 'No docs controller was provided to the HTTP strategy.');
     }
 
-    return R.partial(this.doRequest, [this.docs.handle]);
+    return this._docsRequest;
   };
+
+  _docsRequest: RequestHandler = R.partial(this.doRequest, [this.docs && this.docs.handle]);
 
   /**
    * A middleware to handle supported API requests.

--- a/src/http-strategies/Koa.ts
+++ b/src/http-strategies/Koa.ts
@@ -57,23 +57,25 @@ export default class KoaStrategy extends Base {
         + 'No docs controller was provided to the HTTP strategy.');
     }
 
+    return this._docsRequest;
+  }
+
+  _docsRequest = () => {
     const strategy = this; // tslint:disable-line no-this-assignment
 
-    return function() {
-      return function *(this: any, next: any){
-        const ctx = this; // tslint:disable-line no-this-assignment
-        try {
-          const reqObj = yield strategy.buildRequestObject(ctx.req, ctx.protocol, ctx.host, ctx.params);
-          const resObj = yield strategy.docs.handle(reqObj, ctx.request, ctx.response);
-          const delegate406Handling = strategy.sendResources(resObj, ctx);
-          if(delegate406Handling){
-            yield next;
-          }
+    return function*(this: any, next: any) {
+      const ctx = this; // tslint:disable-line no-this-assignment
+      try {
+        const reqObj = yield strategy.buildRequestObject(ctx.req, ctx.protocol, ctx.host, ctx.params);
+        const resObj = yield strategy.docs && strategy.docs.handle(reqObj, ctx.request, ctx.response);
+        const delegate406Handling = strategy.sendResources(resObj, ctx);
+        if (delegate406Handling) {
+          yield next;
         }
-        catch (err) {
-          strategy.sendError(err, this);
-        }
-      };
+      }
+      catch (err) {
+        strategy.sendError(err, this);
+      }
     };
   }
 

--- a/src/http-strategies/Koa.ts
+++ b/src/http-strategies/Koa.ts
@@ -23,7 +23,7 @@ import Base from "./Base";
  *    can set this option to false to have this code just pass on to Koa.
  */
 export default class KoaStrategy extends Base {
-  constructor(apiController, docsController, options) {
+  constructor(apiController, docsController?, options?) {
     super(apiController, docsController, options);
   }
 
@@ -51,21 +51,29 @@ export default class KoaStrategy extends Base {
   }
 
   // For requests for the documentation.
-  docsRequest() {
+  get docsRequest() {
+    if (this.docs == null) {
+      throw new Error('Cannot get docs request handler. '
+        + 'No docs controller was provided to the HTTP strategy.');
+    }
+
     const strategy = this; // tslint:disable-line no-this-assignment
-    return function *(this: any, next: any){
-      const ctx = this; // tslint:disable-line no-this-assignment
-      try {
-        const reqObj = yield strategy.buildRequestObject(ctx.req, ctx.protocol, ctx.host, ctx.params);
-        const resObj = yield strategy.docs.handle(reqObj, ctx.request, ctx.response);
-        const delegate406Handling = strategy.sendResources(resObj, ctx);
-        if(delegate406Handling){
-          yield next;
+
+    return function() {
+      return function *(this: any, next: any){
+        const ctx = this; // tslint:disable-line no-this-assignment
+        try {
+          const reqObj = yield strategy.buildRequestObject(ctx.req, ctx.protocol, ctx.host, ctx.params);
+          const resObj = yield strategy.docs.handle(reqObj, ctx.request, ctx.response);
+          const delegate406Handling = strategy.sendResources(resObj, ctx);
+          if(delegate406Handling){
+            yield next;
+          }
         }
-      }
-      catch (err) {
-        strategy.sendError(err, this);
-      }
+        catch (err) {
+          strategy.sendError(err, this);
+        }
+      };
     };
   }
 

--- a/test/integration/express-strategy/index.ts
+++ b/test/integration/express-strategy/index.ts
@@ -1,11 +1,28 @@
 import { expect } from "chai";
 import AgentPromise from "../../app/agent";
 import { VALID_ORG_RESOURCE_NO_ID } from "../fixtures/creation";
+import { APIController, httpStrategies, ResourceTypeRegistry } from "../../../src/index"
+
+const { Express } = httpStrategies;
 
 describe("Express Strategy", () => {
   let Agent;
   before(() => {
     return AgentPromise.then(A => { Agent = A; });
+  });
+
+  describe("configuration", () => {
+    const registry = new ResourceTypeRegistry({});
+    const api = new APIController(registry);
+    
+    it("does not require a documentation controller", () => {
+      expect(() => new Express(api)).to.not.throw();
+    });
+
+    it("throws if you attempt to get a docs request handler if no docs controller was provided", () => {
+      const express = new Express(api);
+      expect(() => express.docsRequest).to.throw(/^Cannot get docs request handler/);
+    });
   });
 
   describe("body parsing", () => {


### PR DESCRIPTION
I opted to throw the error in the request handler's getter, rather than in the request handler itself. This means that an app attempting to use a docs handler when not allowed will get an error at boot, rather than at the first docs request.

I've added tests for the `ExpressStrategy`, but not the `KoaStrategy` as that doesn't appear to have any to begin with.

Fixes #157 