### PR TITLE
Decode URI components for sort parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "testdouble": "^3.8.1",
     "ts-node": "^3.3.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.8.4"
+    "typescript": "~2.8.4"
   },
   "peerDependencies": {
     "mongoose": "^4.7.0",

--- a/src/steps/pre-query/parse-query-params.ts
+++ b/src/steps/pre-query/parse-query-params.ts
@@ -112,7 +112,7 @@ export function parseSort(
   rawSortString: string,
   sortOperators: ParserOperatorsConfig
 ): Sort[] {
-  return underlyingSortParser(sortOperators, rawSortString);
+  return underlyingSortParser(sortOperators, decodeURIComponent(rawSortString));
 }
 
 export function parseFilter(

--- a/test/integration/fetch-collection/index.ts
+++ b/test/integration/fetch-collection/index.ts
@@ -153,6 +153,27 @@ describe("Fetching Collection", () => {
     });
   });
 
+  describe("Fetching Multi-Sorted Collection (encoded commas)", () => {
+    let res;
+    before(() => {
+      return Agent.request("GET", "/people?sort=-gender%2Cname")
+        .accept("application/vnd.api+json")
+        .then(response => {
+          res = response;
+        });
+    });
+
+    it("Should have Doug before John; both before Jane", () => {
+      const johnJaneDougList = res.body.data.map((it) => it.attributes.name).filter((it) => {
+        return ["John", "Jane", "Doug"].indexOf(it.substring(0, 4)) > -1;
+      });
+
+      expect(johnJaneDougList).to.deep.equal([
+        "Doug Wilson", "John Smith", "Jane Doe"
+      ]);
+    });
+  });
+
   describe("Fetching with Offset and/or Limit (reverse name sorted for determinism)", () => {
     let res;
     before(() => {


### PR DESCRIPTION
Included the decoding of sorting parameters to support multi-sorting with encoded commas. Existing functionality only supported multi-sorts as long as no encoded commas were used to separate attributes. 

BEFORE 
 - '/people?sort=-gender%2Cname' would interpret '-gender,name' as one attribute instead of multiple

AFTER
 - '/people?sort=-gender%2Cname' interprets as a desc gender sort and asc name sort which is what is expected and behaves the same as '/people?sort=-gender,name'

The test written is identical to an existing fetch multi-sort test with the request altered to include encoded commas.

A change to dependencies was required in order to contribute as my initial typescript version of 2.9.2 resulted in a third of the tests failing due to an export error with Maybe. 
