### PR TITLE
Change include to not use decoded values for parsing.

### DIFF
--- a/src/controllers/API.ts
+++ b/src/controllers/API.ts
@@ -28,7 +28,7 @@ import validateContentType from "../steps/http/content-negotiation/validate-cont
 
 import finalizeOperatorConfig from '../steps/pre-query/finalize-operator-definitions';
 import { getQueryParamValue } from '../util/query-parsing';
-import parseQueryParams, { parseFilter, parseSort } from '../steps/pre-query/parse-query-params';
+import parseQueryParams, { parseFilter, parseSort, parseCommaSeparatedParamString} from '../steps/pre-query/parse-query-params';
 import parseRequestPrimary from "../steps/pre-query/parse-request-primary";
 import setTypePaths from "../steps/set-type-paths";
 import validateRequestDocument from "../steps/pre-query/validate-document";
@@ -194,6 +194,10 @@ export default class APIController {
       ...request,
       queryParams: {
         ...parseQueryParams(request.queryParams),
+        include: getQueryParamValue('include',request.rawQueryString)
+          .map(it => parseCommaSeparatedParamString('include', it))
+          .getOrDefault()
+        ,
         filter: guardedQueryParamParse(
           this.filterParamParser,
           "filter",

--- a/src/controllers/API.ts
+++ b/src/controllers/API.ts
@@ -28,7 +28,7 @@ import validateContentType from "../steps/http/content-negotiation/validate-cont
 
 import finalizeOperatorConfig from '../steps/pre-query/finalize-operator-definitions';
 import { getQueryParamValue } from '../util/query-parsing';
-import parseQueryParams, { parseFilter, parseSort, parseCommaSeparatedParamString} from '../steps/pre-query/parse-query-params';
+import parseQueryParams, { parseFilter, parseSort, parseCommaSeparatedParamString } from '../steps/pre-query/parse-query-params';
 import parseRequestPrimary from "../steps/pre-query/parse-request-primary";
 import setTypePaths from "../steps/set-type-paths";
 import validateRequestDocument from "../steps/pre-query/validate-document";

--- a/src/controllers/API.ts
+++ b/src/controllers/API.ts
@@ -28,7 +28,7 @@ import validateContentType from "../steps/http/content-negotiation/validate-cont
 
 import finalizeOperatorConfig from '../steps/pre-query/finalize-operator-definitions';
 import { getQueryParamValue } from '../util/query-parsing';
-import parseQueryParams, { parseFilter, parseSort, parseCommaSeparatedParamString } from '../steps/pre-query/parse-query-params';
+import parseQueryParams, { parseFilter, parseSort } from '../steps/pre-query/parse-query-params';
 import parseRequestPrimary from "../steps/pre-query/parse-request-primary";
 import setTypePaths from "../steps/set-type-paths";
 import validateRequestDocument from "../steps/pre-query/validate-document";
@@ -193,11 +193,7 @@ export default class APIController {
     const finalizedRequest: FinalizedRequest = {
       ...request,
       queryParams: {
-        ...parseQueryParams(request.queryParams),
-        include: getQueryParamValue('include',request.rawQueryString)
-          .map(it => parseCommaSeparatedParamString('include', it))
-          .getOrDefault()
-        ,
+        ...parseQueryParams(request.queryParams, request.rawQueryString),
         filter: guardedQueryParamParse(
           this.filterParamParser,
           "filter",

--- a/src/steps/pre-query/parse-query-params.ts
+++ b/src/steps/pre-query/parse-query-params.ts
@@ -96,7 +96,7 @@ function parseScopedParam(paramName: string, scopedParam: ScopedParam) {
   return scopedParam;
 }
 
-export function parseCommaSeparatedParamString(paramName: string, encodedString: any) {
+export function parseCommaSeparatedParamString(paramName: string, encodedString: string) {
   if(typeof encodedString !== 'string')
     throw Errors.invalidQueryParamValue({
       detail: "Expected a comma-separated list of strings.",

--- a/src/steps/pre-query/parse-query-params.ts
+++ b/src/steps/pre-query/parse-query-params.ts
@@ -11,7 +11,7 @@ import {
   ParserOperatorsConfig,
   FieldExpression as FieldExprType
 } from "../../types/index";
-
+import { getQueryParamValue } from '../../util/query-parsing';
 // Helpers for working with filter/sort param parse results.
 export const isFieldExpression =
   (it: any): it is FieldExprType => it && it.type === "FieldExpression";
@@ -40,7 +40,7 @@ export type ParsedStandardQueryParams = {
   [paramName: string]: any;
 };
 
-export default function(params: RawParams): ParsedStandardQueryParams {
+export default function(params: RawParams, rawQueryString: string | undefined): ParsedStandardQueryParams {
   const paramsToParserFns = {
     page: R.pipe(
       R.partial(parseScopedParam, ["page"]),
@@ -59,11 +59,15 @@ export default function(params: RawParams): ParsedStandardQueryParams {
     fields: parseFieldsParam
   };
 
-  return R.mapObjIndexed((v: any, paramName: string) => {
+  const standardQueryParams = R.mapObjIndexed((v: any, paramName: string) => {
     return !R.has(paramName, paramsToParserFns)
       ? v
       : paramsToParserFns[paramName](v);
   }, params);
+  standardQueryParams.include = getQueryParamValue('include', rawQueryString)
+    .map(it => parseCommaSeparatedParamString('include', it))
+    .getOrDefault()
+  return standardQueryParams;
 }
 
 const isScopedParam = R.is(Object);
@@ -96,7 +100,7 @@ function parseScopedParam(paramName: string, scopedParam: ScopedParam) {
   return scopedParam;
 }
 
-export function parseCommaSeparatedParamString(paramName: string, encodedString: string) {
+function parseCommaSeparatedParamString(paramName: string, encodedString: string) {
   if(typeof encodedString !== 'string')
     throw Errors.invalidQueryParamValue({
       detail: "Expected a comma-separated list of strings.",

--- a/src/types/Generic/Data.ts
+++ b/src/types/Generic/Data.ts
@@ -197,7 +197,7 @@ export default class Data<T> {
    * (it => Data.empty) the resulting monad still has isSingular as false.
    * If it were a true zero, binding to toMzero would give you isSingular true.
    * That doesn't happen though because the monoidal part of the metadata
-   * is appended to in flatMap not reset. 
+   * is appended to in flatMap not reset.
    * See https://en.wikipedia.org/wiki/Monad_(functional_programming)#Additive_monads
    * @type {[type]}
    */

--- a/src/util/query-parsing.ts
+++ b/src/util/query-parsing.ts
@@ -7,8 +7,10 @@ export { Just, Nothing };
  * This is used because the raw parse result from `qs` automatically urldecodes
  * characters prematurely for some of our parsing purposes.
  *
- * query paramter is parsed according to application/x-www-form-urlencoded:
- * https://url.spec.whatwg.org/#urlencoded-parsing
+ * Query parameter names are extracted according to application/x-www-form-urlencoded
+ * (https://url.spec.whatwg.org/#urlencoded-parsing), while query parameter values are left exactly
+ * as they occur in the URL, per JSON:API's allowance:
+ * https://jsonapi.org/format/1.1/#appendix-query-details-parsing
  */
 export const getQueryParamValue =
   R.curry((paramName: string, queryString: string | undefined) => {
@@ -24,8 +26,8 @@ function parseSingleQueryParamString(paramString: string) {
   const firstEqualPos = paramString.indexOf("=");
   const [parsedKey, rawValue] = firstEqualPos === -1
     ? [decodeURIComponent(paramString.replace("+"," ")), ""]
-    : [decodeURIComponent(paramString.slice(0, paramString.indexOf("=")).replace("+"," ")),
-      paramString.substr(paramString.indexOf("=")+1)];
+    : [decodeURIComponent(paramString.slice(0, firstEqualPos).replace("+"," ")),
+      paramString.substr(firstEqualPos+1)];
   return [parsedKey, rawValue]
 }
 

--- a/src/util/query-parsing.ts
+++ b/src/util/query-parsing.ts
@@ -6,24 +6,26 @@ export { Just, Nothing };
  * Find the (raw/urlencoded) value of a query parameter from a query string.
  * This is used because the raw parse result from `qs` automatically urldecodes
  * characters prematurely for some of our parsing purposes.
+ *
+ * query paramter is parsed according to application/x-www-form-urlencoded:
+ * https://url.spec.whatwg.org/#urlencoded-parsing
  */
 export const getQueryParamValue =
   R.curry((paramName: string, queryString: string | undefined) => {
     return Maybe(queryString).map(it =>
       it.split("&").reduce((acc: string | undefined, paramString) => {
-        const [rawKey, rawValue] = splitSingleQueryParamString(paramString);
-        return rawKey === paramName ? rawValue : acc;
+        const [parsedKey, rawValue] = parseSingleQueryParamString(paramString);
+        return parsedKey === paramName ? rawValue : acc;
       }, undefined)
     );
   });
 
-function splitSingleQueryParamString(paramString: string) {
-  const bracketEqualsPos = paramString.indexOf("]=");
-  const delimiterPos =
-    bracketEqualsPos === -1 ? paramString.indexOf("=") : bracketEqualsPos + 1;
-
-  // returning [undecoded key, undecoded value]
-  return delimiterPos === -1
-    ? [paramString, ""]
-    : [paramString.slice(0, delimiterPos), paramString.slice(delimiterPos + 1)];
+function parseSingleQueryParamString(paramString: string) {
+  const firstEqualPos = paramString.indexOf("=");
+  const [parsedKey, rawValue] = firstEqualPos === -1
+    ? [decodeURIComponent(paramString.replace("+"," ")), ""]
+    : [decodeURIComponent(paramString.slice(0, paramString.indexOf("=")).replace("+"," ")),
+      paramString.substr(paramString.indexOf("=")+1)];
+  return [parsedKey, rawValue]
 }
+

--- a/test/app/database/define-fixtures.ts
+++ b/test/app/database/define-fixtures.ts
@@ -20,7 +20,7 @@ fixtures.save("all", {
   // as the query transform and sorting tests depend on those.
   Person: [
     { name: "John Smith", email: "jsmith@gmail.com", gender: "male", _id: smithId },
-    { name: "Jane Doe", gender: "female", _id: doeId, manages: elementaryId, homeSchool: elementaryId },
+    { name: "Jane Doe", gender: "female", _id: doeId, manages: govtId, homeSchool: elementaryId },
     { name: "Doug Wilson", gender: "male" },
     { name: "Jordi Jones", _id: genderPersonId, gender: "other" },
     { name: "An Inivisible Sorcerer", gender: "other", _id: invisibleResourceId },

--- a/test/integration/fetch-collection/index.ts
+++ b/test/integration/fetch-collection/index.ts
@@ -314,6 +314,7 @@ describe("Fetching Collection", () => {
         .query("include=manages%2ChomeSchool")
         .accept("application/vnd.api+json")
         .then(() => {
+          throw new Error("should not get here");
         }, (err) => {
           expect(err.response.status).to.equal(400);
           expect(err.response.body.errors[0].source.parameter).to.eq("manages,homeSchool");

--- a/test/integration/fetch-collection/index.ts
+++ b/test/integration/fetch-collection/index.ts
@@ -292,6 +292,35 @@ describe("Fetching Collection", () => {
         });
     });
   });
+
+  describe("Fetching with multiple includes", () => {
+    it("should return organisation and schools related that people relate to", () => {
+      return Agent.request("GET", "/people")
+        .query("include=manages,homeSchool")
+        .accept("application/vnd.api+json")
+        .then(res => {
+          const stateGovernment =
+            res.body.included.filter(it => it.attributes.name === 'STATE GOVERNMENT');
+          const elementarySchool =
+            res.body.included.filter(it => it.attributes.name === 'ELEMENTARY SCHOOL');
+
+          expect(stateGovernment).to.have.length(1);
+          expect(elementarySchool).to.have.length(1);
+        });
+    });
+
+    it("should error if relationship names are encoded comma seperated", () => {
+      return Agent.request("GET", "/people")
+        .query("include=manages%2ChomeSchool")
+        .accept("application/vnd.api+json")
+        .then(() => {
+        }, (err) => {
+          expect(err.response.status).to.equal(400);
+          expect(err.response.body.errors[0].source.parameter).to.eq("manages,homeSchool");
+        });
+    });
+  });
+
 });
 
     // "[S]erver implementations MUST ignore

--- a/test/unit/util/query-parsing.ts
+++ b/test/unit/util/query-parsing.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { getQueryParamValue } from "../../../src/util/query-parsing";
+
+describe("Query Parameter Parsing", () => {
+  it("should split on first equals '='", () => {
+    const paramString = "filter=some=Value"
+    expect(getQueryParamValue("filter",paramString).getOrDefault()).to.equal("some=Value");
+  });
+
+  it("should give empty name if '=' start of sequence", () => {
+    const paramString = "=someValue"
+    expect(getQueryParamValue("",paramString).getOrDefault()).to.equal("someValue");
+  });
+
+  it("should give empty value if '=' end of sequence", () => {
+    const paramString = "filter="
+    expect(getQueryParamValue("filter",paramString).getOrDefault()).to.equal("");
+  });
+
+  it("should make name entire sequence if no '='", () => {
+    const paramString = "hello"
+    expect(getQueryParamValue("hello",paramString).getOrDefault()).to.equal("");
+  });
+
+  it("should return raw value", () => {
+    const paramString = "filter=he%2Cl$3Fl%4Fo"
+    expect(getQueryParamValue("filter",paramString).getOrDefault()).to.equal("he%2Cl$3Fl%4Fo");
+  });
+
+  it("should decode and replace '+' with 'SP' in names for matching purpose", () => {
+    const paramString = "spa+ce%5Boffset%5D=1"
+    expect(getQueryParamValue("spa ce[offset]",paramString).getOrDefault()).to.equal("1");
+  });
+});


### PR DESCRIPTION
[related conversation](https://github.com/ethanresnick/json-api/pull/184#issuecomment-454650824) 

 - parsing of ``?include`` takes from ``rawQueryString`` instead
 - error thrown, if invalid member name for ``include``
 - update of query parameter util function to match spec, while leaving parameter handling as is
 - tests testing functionality for above changes