### PR TITLE
Allow queryTransform to return a promise

### DIFF
--- a/src/controllers/API.ts
+++ b/src/controllers/API.ts
@@ -106,12 +106,12 @@ export type ResultBuildingContext = QueryBuildingContext;
 // approach that the express typings seem to use, so I imagine it's safe enough.
 export type QueryTransformNoReq = {
   // tslint:disable-next-line callable-types
-  (first: RunnableQuery): RunnableQuery;
+  (first: RunnableQuery): RunnableQuery | Promise<RunnableQuery>;
 };
 
 export type QueryTransformWithReq = {
   // tslint:disable-next-line callable-types
-  (first: ServerReq, second: RunnableQuery): RunnableQuery;
+  (first: ServerReq, second: RunnableQuery): RunnableQuery | Promise<RunnableQuery>;
 };
 
 export type RequestOpts = {

--- a/test/app/src/index.ts
+++ b/test/app/src/index.ts
@@ -85,6 +85,17 @@ export default database.then(function(dbModule) {
     })
   );
 
+  app.get('/request-with-async-transform/:type(people)/:id(42)',
+    Front.customAPIRequest({
+      queryTransform: (query: RunnableQuery) =>
+        Promise.resolve(
+          query.resultsIn(undefined, () => ({
+            document: new Document({})
+          }))
+        )
+    })
+  );
+
   // Apply a query transform that returns a custom error
   app.get('/request-that-errors/:type(people)/:id(42)',
     Front.customAPIRequest({

--- a/test/integration/custom-query/index.ts
+++ b/test/integration/custom-query/index.ts
@@ -17,6 +17,14 @@ describe("Customizing the Query", () => {
       });
   });
 
+  it("should rceive an empty response from an async query transform without error", () => {
+    return Agent.request("GET", "/request-with-async-transform/people/42")
+      .accept("application/vnd.api+json")
+      .then((res) => {
+        expect(res).to.be.ok
+      });
+  });
+
   it("should run the resultingIn transform to create a custom error", () => {
     return Agent.request("GET", "/request-that-errors/people/42")
       .accept("application/vnd.api+json")


### PR DESCRIPTION
It is already the case that queryTransform can return a promise for a RunnableQuery instead of a Runnable query but it was not in the type definition or covered in any test so I've added those two things.

Unfortunately I couldn't get the tests to run, I get the following error `Error: Cannot find module 'superagent'`. As far as I can tell, superagent is present in the node_modules after installing but there is no JS entry point. I'm not quite sure what is going on there. I therefore can't confirm whether the test I wrote passes. I can at least be fairly sure that I didn't break any other tests as all I changed is a type definition.