### PR TITLE
Allow to use json-api with mongoose@6 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "^2.8.4"
   },
   "peerDependencies": {
-    "mongoose": "^4.7.0",
+    "mongoose": "^4.7.0 || ^6",
     "express": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
mongoose@6 works as expected, no issues was observed.

I would be happy to update it in devDependencies also, but I am not sure of your upgrade policy: should json-api target latest mongoose or a wide range including previous major releases. Please advice me on target versions for mongoose.